### PR TITLE
Add SvelteMarkdown for speakers

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	"type": "module",
 	"dependencies": {
 		"@fontsource/fira-mono": "^4.5.8",
-		"daisyui": "^2.17.0"
+		"daisyui": "^2.17.0",
+		"svelte-markdown": "^0.2.2"
 	}
 }

--- a/src/content/speakers.md
+++ b/src/content/speakers.md
@@ -13,6 +13,8 @@ members:
     image: https://www.future-of-research-software.org/FabioKon-IEA-Alta2%20(1).jpg
     desc: "Fabio Kon is a Full Professor of Computer Science at the [Institute of Mathematics and Statistics at the University of São Paulo (IME-USP)](https://www.ime.usp.br/en/home/). He carries out research in the fields of Software Engineering, Smart Cities, Free and Open Source Software, and Innovation and  Technological Entrepreneurship. In 2013, he was Visiting Professor at the Technion, Israel, where he conducted research on Software Startup Ecosystems and Digital Entrepreneurship. In 2018-19, he was a Visiting Professor at [Massachusetts Institute of Technology (MIT)](https://www.mit.edu/), USA, where he researched data science applied to Smart Cities.
 
+
+    <br/>
 Prof. Kon is highly involved in education and in promoting the best practices of software engineering, open-source software, and open science. He is a member of the [São Paulo Research Foundation (FAPESP)](https://fapesp.br/en/about) Adjunct Panel for Exact Sciences and Engineering."
 
 ---

--- a/src/routes/speakers.svelte
+++ b/src/routes/speakers.svelte
@@ -1,5 +1,6 @@
 <script>
   import SpeakersIntroduction from "$content/speakers.md";
+  import SvelteMarkdown from 'svelte-markdown';
 
   export const [{ metadata }] = Object.values(import.meta.globEager("$content/speakers.md"))
 </script>
@@ -18,7 +19,9 @@
             <h4 class="mb-2 text-2xl font-bold font-heading">
               { member.name }
             </h4>
-            <p class="mb-4 text-gray-700 leading-loose">{ member.desc }</p>
+            <p class="mb-4 text-gray-700 leading-loose">
+              <SvelteMarkdown source={member.desc} />
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
@VeronicaWYPang -- this should make the markdown links render properly on the speakers page.